### PR TITLE
return key when translated result is undefined

### DIFF
--- a/src/localize-router.parser.ts
+++ b/src/localize-router.parser.ts
@@ -353,7 +353,7 @@ export abstract class LocalizeParser {
     if(res.includes(this.prefix + ':')) {
       res = undefined;
     }
-    return res || key;
+    return res === undefined ? key : res;
   }
 }
 


### PR DESCRIPTION
return the value of key when translated result is undefined. Otherwise return the result itself.
This commit makes it possible to have  empty ```path``` value in router config, which is really needed while lazy loading feature module.